### PR TITLE
FEM-2733 Audio casting fails

### DIFF
--- a/Sources/CAFCastBuilder.swift
+++ b/Sources/CAFCastBuilder.swift
@@ -296,7 +296,7 @@ import GoogleCast
         mediaInfoData["protocol"] = self.httpProtocol.description
         
         if let formats = self.formats {
-            mediaInfoData["formats"] = formats.description
+            mediaInfoData["formats"] = formats
         }
         
         if let fileIds = self.fileIds {


### PR DESCRIPTION
Fixed the formats to send the array of string values and not a string of the array.